### PR TITLE
merge[#4] Desarrollar script de calcular_metricas.py

### DIFF
--- a/metricas/commits.csv
+++ b/metricas/commits.csv
@@ -1,0 +1,6 @@
+commit_hash,fecha,tipo_de_issue
+a066af57769041d809ecd9ccfdc49828b6e4979b,2025-06-07 14:37:26 -0500,merge[#2]: Fusionar rama feature-git-hook-commit-msg
+2badba24e6337acd8d0bd3623f259b69fd5f85b7,2025-06-07 14:16:43 -0500,feat[#2]: Implementar git hook commit-msg
+dd7f0d82c20723421cad478417c7fbbeac2290e4,2025-06-07 13:34:38 -0500,merge[#1]: Fusionar rama feature-estructura
+c53fe9c8b64135b3f7241c423c8e3750053cf4c6,2025-06-07 12:59:43 -0500,feat[#1]: Inicializar repositorio y estructura
+2f1a006a839a69846ad239df3e5848772a4ad9f1,2025-06-06 18:13:21 -0500,feat[#0]: Agregar plantilla de Historia Usuario

--- a/src/calcular_metricas.py
+++ b/src/calcular_metricas.py
@@ -1,0 +1,39 @@
+import subprocess
+import csv
+
+
+# funcion que captura el historial de commits de un repositorio git
+def registrar_git_log():
+    # captura la salida del comando git log
+    try:
+        historial = subprocess.run(
+            ['git', 'log', '--pretty=format:%H|%ad|%s', '--date=iso'],
+            capture_output=True, text=True, check=True
+        )
+        commits = []
+        for line in historial.stdout.splitlines():
+            commit_hash, date, message = line.split('|', 2)
+            commits.append((commit_hash, date, message))
+        return commits
+    except subprocess.CalledProcessError as e:
+        print(f"error al ejecutar el comando git log: {e}")
+        return []
+
+
+# funcion que escribe los datos de los commits en un archivo CSV
+def escribir_csv(commits, output_file='metricas/commits.csv'):
+    # escribe los datos en un archivo CSV
+    try:
+        with open(output_file, 'w', newline='') as f:
+            writer = csv.writer(f)
+            writer.writerow(['commit_hash', 'fecha', 'tipo_de_issue'])
+            for commit in commits:
+                writer.writerow(commit)
+    except IOError as e:
+        print(f"error al escribir en el CSV: {e}")
+
+
+# main
+if __name__ == "__main__":
+    commits = registrar_git_log()
+    escribir_csv(commits)


### PR DESCRIPTION
### Se implemento el script calcular_metricas.py con las funciones como parte del Issue #4 :
- **registrar_git_log()**: funcion que captura el historial de commits de un repositorio git 
- **escribir_csv()**: funcion que escribe los datos de los commits en un archivo CSV
Se creo el archivo metricas/commits.csv en la compilacion de calcular_metricas.py